### PR TITLE
Prevent missing LANGUAGE_CODE error in redirect

### DIFF
--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -38,6 +38,6 @@ class TranslationMiddleware(MiddlewareMixin):
         request.LANGUAGE_CODE = active_language
 
     def process_response(self, request, response):
-        if 'Content-Language' not in response:
+        if 'Content-Language' not in response and hasattr(request, 'LANGUAGE_CODE'):
             response['Content-Language'] = request.LANGUAGE_CODE
         return response


### PR DESCRIPTION
Django 1.11
Wagtail 2.0
