### PR TITLE
Add a disable_for_loaddata decorator on signals

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -35,6 +35,25 @@ additional languages per site. This is mostly used in a ``multi site`` setup and
 allowes you to define the languages per site, this way they can differ for all
 available sites.
 
+.. note::
+
+    When using Django's loaddata wagtailtrans detaches all signals so there
+    aren't any weird side-effects triggered when loading your data. However
+    using loaddata in combination with ``WAGTAILTRANS_LANGUAGES_PER_SITE`` there
+    is still one signal which can't be detatched ``m2m_changed`` to do this you
+    can provide the environment variable ``WAGTAILTRANS_DISABLE_SIGNALS=True`` to
+    your loadddata command, this will skip adding the signals as well.
+
+    Example:
+
+        ``WAGTAILTRANS_DISABLE_SIGNALS=True ./manage.py loaddata data.json``
+
+
+.. danger::
+
+    Using ``WAGTAILTRANS_DISABLE_SIGNALS`` can potentially break your complete
+    wagtailtrans installation, when used incorrectly.
+
 
 ``WAGTAILTRANS_HIDE_TRANSLATION_TREES``
 ---------------------------------------

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -1,14 +1,14 @@
+import os
 from functools import wraps
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import m2m_changed, post_save, pre_delete
+
 from wagtail.admin.signals import init_new_page
 from wagtail.core.models import Site, get_page_models
-
 from wagtailtrans.conf import get_wagtailtrans_setting
 from wagtailtrans.models import Language, SiteLanguages, TranslatablePage
-from wagtailtrans.permissions import (
-    create_group_permissions, get_or_create_language_group)
+from wagtailtrans.permissions import create_group_permissions, get_or_create_language_group
 
 
 def disable_for_loaddata(signal_handler):
@@ -16,7 +16,8 @@ def disable_for_loaddata(signal_handler):
 
     @wraps(signal_handler)
     def wrapper(*args, **kwargs):
-        if kwargs.get('raw'):
+        disable_signals = os.environ.get('WAGTAILTRANS_DISABLE_SIGNALS', False)
+        if kwargs.get('raw') or bool(disable_signals):
             return
         signal_handler(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
When using loaddata to load a database dump we don't want to
automatically create localized pages since that will conflict with
the dump loading process. We can also assume that the dump already
contains the localized pages.

This change checks for the `raw` kwarg in the signal handlers and
exists the function if it is True.

### Thanks for contributing!

Please make sure all the tests pass, before creating a pull-request.
