### PR TITLE
Show languages in their local names.

### DIFF
--- a/src/wagtailtrans/templates/wagtailtrans/templatetags/language_selector.html
+++ b/src/wagtailtrans/templates/wagtailtrans/templatetags/language_selector.html
@@ -1,10 +1,14 @@
+{% load i18n %}
+
 <ul class="language-selector">
     <li class="active-language">
-        <a href="{{ current_page.url }}">{{ current_page.language }}</a>
+        {% get_language_info for current_page.language.code as lang %}
+        <a href="{{ current_page.url }}">{{ lang.name_local }}</a>
     </li>
     {% for language, page in translations.items %}
+    {% get_language_info for language.code as lang %}
     <li>
-        <a href="{{ page.url }}">{{ language }}</a>
+        <a href="{{ page.url }}">{{ lang.name_local }}</a>
     </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
In language selector, it is preferable to show languages in their local names.
See https://ux.stackexchange.com/questions/37017/language-of-language-names-in-the-language-selector
