### PR TITLE
Add Wagtail 2.7 LTS and 2.8 to the testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
   include:
     # Wagtail 2.3 LTS to cover support until 2.7
     # Django 1.11
-    - env: TOXENV=py35-dj11-wt23
+    - env: TOXENV=py35-dj111-wt23
       python: 3.5
-    - env: TOXENV=py36-dj11-wt23
+    - env: TOXENV=py36-dj111-wt23
       python: 3.6
 
     # Django 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,6 @@ matrix:
       python: 3.8
 
     # Django 3.0
-    - env: TOXENV=py35-dj30-wt28
-      python: 3.5
     - env: TOXENV=py36-dj30-wt28
       python: 3.6
     - env: TOXENV=py37-dj30-wt28

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,136 +1,113 @@
-sudo: false
 language: python
 cache: pip
+dist: xenial
+
+services:
+  - postgresql
+addons:
+    postgresql: "10"
+
 matrix:
   include:
+    # Wagtail 2.3 LTS to cover support until 2.7
     # Django 1.11
-    # Wagtail 2.0
-    - env: TOXENV=py35-dj111-wt2
+    - env: TOXENV=py35-dj11-wt23
       python: 3.5
-    - env: TOXENV=py36-dj111-wt2
+    - env: TOXENV=py36-dj11-wt23
       python: 3.6
-    - env: TOXENV=py37-dj111-wt2
-      python: 3.7
 
-    # Django 1.11
-    # Wagtail 2.1
-    - env: TOXENV=py35-dj111-wt21
+    # Django 2.0
+    - env: TOXENV=py35-dj20-wt23
       python: 3.5
-    - env: TOXENV=py36-dj111-wt21
+    - env: TOXENV=py36-dj20-wt23
       python: 3.6
-    - env: TOXENV=py37-dj111-wt21
-      python: 3.7
-
-    # Django 1.11
-    # Wagtail 2.2
-    - env: TOXENV=py35-dj111-wt22
-      python: 3.5
-    - env: TOXENV=py36-dj111-wt22
-      python: 3.6
-    - env: TOXENV=py37-dj111-wt22
-      python: 3.7
-
-    # Django 1.11
-    # Wagtail 2.3
-    - env: TOXENV=py35-dj111-wt23
-      python: 3.5
-    - env: TOXENV=py36-dj111-wt23
-      python: 3.6
-    - env: TOXENV=py37-dj111-wt23
-      python: 3.7
-
-    # Django 1.11
-    # Wagtail 2.4
-    - env: TOXENV=py35-dj111-wt24
-      python: 3.5
-    - env: TOXENV=py36-dj111-wt24
-      python: 3.6
-    - env: TOXENV=py37-dj111-wt24
-      python: 3.7
 
     # Django 2.1
-    # Wagtail 2.3
     - env: TOXENV=py35-dj21-wt23
       python: 3.5
     - env: TOXENV=py36-dj21-wt23
       python: 3.6
-    - env: TOXENV=py37-dj21-wt23
-      python: 3.7
-      sudo: true
-      dist: xenial
-
-    # Django 2.1
-    # Wagtail 2.4
-    - env: TOXENV=py35-dj21-wt24
+    
+    # Wagtail 2.7 LTS
+    # Django 2.0
+    - env: TOXENV=py35-dj20-wt27
       python: 3.5
-    - env: TOXENV=py36-dj21-wt24
+    - env: TOXENV=py36-dj20-wt27
       python: 3.6
-    - env: TOXENV=py37-dj21-wt24
+    - env: TOXENV=py37-dj20-wt27
       python: 3.7
-      sudo: true
-      dist: xenial
-
+    - env: TOXENV=py38-dj20-wt27
+      python: 3.8
+    
     # Django 2.1
-    # Wagtail 2.5
-    - env: TOXENV=py35-dj21-wt25
+    - env: TOXENV=py35-dj21-wt27
       python: 3.5
-    - env: TOXENV=py36-dj21-wt25
+    - env: TOXENV=py36-dj21-wt27
       python: 3.6
-    - env: TOXENV=py37-dj21-wt25
+    - env: TOXENV=py37-dj21-wt27
       python: 3.7
-      sudo: true
-      dist: xenial
-
-    # Django 2.1
-    # Wagtail 2.6
-    - env: TOXENV=py35-dj21-wt26
-      python: 3.5
-    - env: TOXENV=py36-dj21-wt26
-      python: 3.6
-    - env: TOXENV=py37-dj21-wt26
-      python: 3.7
-      sudo: true
-      dist: xenial
+    - env: TOXENV=py38-dj21-wt27
+      python: 3.8
 
     # Django 2.2
-    # Wagtail 2.5
-    - env: TOXENV=py35-dj22-wt25
+    - env: TOXENV=py35-dj22-wt27
       python: 3.5
-    - env: TOXENV=py36-dj22-wt25
+    - env: TOXENV=py36-dj22-wt27
       python: 3.6
-    - env: TOXENV=py37-dj22-wt25
+    - env: TOXENV=py37-dj22-wt27
       python: 3.7
-      sudo: true
-      dist: xenial
+    - env: TOXENV=py38-dj22-wt27
+      python: 3.8
 
+
+    # Wagtail 2.8
+    # Django 2.1
+    - env: TOXENV=py35-dj21-wt28
+      python: 3.5
+    - env: TOXENV=py36-dj21-wt28
+      python: 3.6
+    - env: TOXENV=py37-dj21-wt28
+      python: 3.7
+    - env: TOXENV=py38-dj21-wt28
+      python: 3.8
+    
     # Django 2.2
-    # Wagtail 2.6
-    - env: TOXENV=py35-dj22-wt26
+    - env: TOXENV=py35-dj22-wt28
       python: 3.5
-    - env: TOXENV=py36-dj22-wt26
+    - env: TOXENV=py36-dj22-wt28
       python: 3.6
-    - env: TOXENV=py37-dj22-wt26
+    - env: TOXENV=py37-dj22-wt28
       python: 3.7
-      sudo: true
-      dist: xenial
+    - env: TOXENV=py38-dj22-wt28
+      python: 3.8
 
+    # Django 3.0
+    - env: TOXENV=py35-dj30-wt28
+      python: 3.5
+    - env: TOXENV=py36-dj30-wt28
+      python: 3.6
+    - env: TOXENV=py37-dj30-wt28
+      python: 3.7
+    - env: TOXENV=py38-dj30-wt28
+      python: 3.8
 
     # Flake 8
     - env: TOXENV=flake8
-      python: 3.6
+      python: 3.7
 
   allow_failures:
     # wagtail dev
     - env: TOXENV=wagtaildev
-      python: 3.6
+      python: 3.7
 
+# Package installation
 install:
   - pip install codecov tox
+
+# Run the tests
 script:
   - tox -e $TOXENV
-services:
-  - postgresql
-addons:
-    postgresql: 10
+
+# After the tests
 after_success:
   - codecov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-X.X.X (XX-XX-XXXX)
-------------------
+2.1 (XX-XX-XXXX)
+----------------
+
+- Dropped support for Wagtail versions earlier than 2.3
+- Added support for Wagtail 2.8 and therefore Django 3.0
 
 
 2.0.6 (11-03-2019)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We appreciate all kinds of support, whether it's on bug reports, code, documenta
 
 ## Issue tracker
 
-The Github [issue tracker](https://github.com/LUKKIEN/wagtailtrans/issues) is the preferred channel for bug reports,
+The Github [issue tracker](https://github.com/wagtail/wagtailtrans/issues) is the preferred channel for bug reports,
 feature requests and submitting pull-requests. Please don't use this for support of any kind.
 
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint:
 	@flake8 src --exclude migrations
 
 isort:
-	isort `find . -name '*.py' -not -path '*/migrations/*'`
+	isort --recursive src tests --skip migrations
 
 dist: clean
 	@python setup.py sdist bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requirements
 
  - Python 3.5+
  - Django 1.11+
- - Wagtail 2.0+
+ - Wagtail 2.3+
 
 
 Getting started

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -11,7 +11,7 @@ documentation, tests or feature requests.
 Issues
 ------
 
-Our Github `issue tracker <https://github.com/LUKKIEN/wagtailtrans/issues>`_ is the preferred channel for bug reports, feature requests and submitting pull requests. When creating new issues please provide as much relevant context as possible. Even your detailed comments on existing issues are a big help.
+Our Github `issue tracker <https://github.com/wagtail/wagtailtrans/issues>`_ is the preferred channel for bug reports, feature requests and submitting pull requests. When creating new issues please provide as much relevant context as possible. Even your detailed comments on existing issues are a big help.
 
 Pull request
 ------------
@@ -36,7 +36,7 @@ Wagtailtrans made it very easy to setup a runnable Django project to help with t
 
 * **Get the codebase**
 
-  Get a copy of the `Wagtailtrans codebase <https://github.com/LUKKIEN/wagtailtrans>`_. Create your own fork and make changes there. For a brief, take a look at this `guideline <https://guides.github.com/activities/forking/>`_.
+  Get a copy of the `Wagtailtrans codebase <https://github.com/wagtail/wagtailtrans>`_. Create your own fork and make changes there. For a brief, take a look at this `guideline <https://guides.github.com/activities/forking/>`_.
 
 \
 

--- a/docs/source/releases/2.1.rst
+++ b/docs/source/releases/2.1.rst
@@ -1,0 +1,27 @@
+==============================
+Wagtailtrans 2.1 release notes
+==============================
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+-----------
+What is new
+-----------
+
+This release is a new major since it will only support Wagtail 2.3 and up.
+
+Features
+~~~~~~~~
+
+- Dropped support for Wagtail versions earlier than 2.3
+- Added support for Wagtail 2.8 and therefore Django 3.0
+
+
+------------------------------
+Backwards incompatible changes
+------------------------------
+
+This release drops support for Wagtail versions below 2.3.

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -8,6 +8,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    2.1
     2.0.6
     2.0.5
     2.0.4

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from wagtailtrans import get_version  # noqa isort:skip
 
 sandbox_require = [
-    'Django>=2.1',
-    'Wagtail>=2.3rc1',
+    'Django>=3.0',
+    'Wagtail>=2.8rc1',
     'psycopg2>=2.5.4',
     'djangorestframework>=3.7',
 ]
@@ -60,10 +60,12 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Framework :: Wagtail',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ]

--- a/src/wagtailtrans/__init__.py
+++ b/src/wagtailtrans/__init__.py
@@ -1,6 +1,6 @@
 default_app_config = 'wagtailtrans.apps.WagtailTransConfig'
 
-VERSION = (2, 0, 7, 'dev1')
+VERSION = (2, 1, 0, 'dev1')
 
 
 def get_version():

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -11,7 +11,6 @@ from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 from django.utils.translation import activate
 from django.utils.translation import ugettext_lazy as _
-
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 from wagtail.contrib.settings.models import BaseSetting

--- a/src/wagtailtrans/permissions.py
+++ b/src/wagtailtrans/permissions.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import Group, Permission
 from wagtail.core.models import (
-    Collection, GroupCollectionPermission, GroupPagePermission,
-    PagePermissionTester, UserPagePermissionsProxy)
+    Collection, GroupCollectionPermission, GroupPagePermission, PagePermissionTester, UserPagePermissionsProxy)
 
 from wagtailtrans.conf import get_wagtailtrans_setting
 

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -3,9 +3,9 @@ from functools import wraps
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import m2m_changed, post_save, pre_delete
-
 from wagtail.admin.signals import init_new_page
 from wagtail.core.models import Site, get_page_models
+
 from wagtailtrans.conf import get_wagtailtrans_setting
 from wagtailtrans.models import Language, SiteLanguages, TranslatablePage
 from wagtailtrans.permissions import create_group_permissions, get_or_create_language_group

--- a/src/wagtailtrans/views/translation.py
+++ b/src/wagtailtrans/views/translation.py
@@ -1,5 +1,5 @@
-from django.urls import reverse
 from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from wagtail.admin.views.generic import CreateView
 

--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -4,10 +4,10 @@ from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
-
 from wagtail.admin import widgets
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
+
 from wagtailtrans.conf import get_wagtailtrans_setting
 from wagtailtrans.models import Language, TranslatablePage
 from wagtailtrans.urls import translations

--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -1,5 +1,8 @@
 from django.conf.urls import include, url
-from django.contrib.staticfiles.templatetags.staticfiles import static
+try:
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+except ImportError:
+    from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.html import format_html

--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -1,8 +1,5 @@
 from django.conf.urls import include, url
-try:
-    from django.contrib.staticfiles.templatetags.staticfiles import static
-except ImportError:
-    from django.templatetags.static import static
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.html import format_html

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -12,7 +12,6 @@
 """
 import os
 
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/_sandbox/settings/base.py
+++ b/tests/_sandbox/settings/base.py
@@ -12,7 +12,6 @@
 """
 import os
 
-from django import VERSION as django_version
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -75,9 +74,6 @@ MIDDLEWARE = [
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'wagtailtrans.middleware.TranslationMiddleware'
 ]
-
-if django_version < (1, 10):
-    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'tests._sandbox.urls'
 

--- a/tests/factories/pages.py
+++ b/tests/factories/pages.py
@@ -1,12 +1,10 @@
 import factory
 from wagtail.core.models import Page
-from wagtail.images.tests.utils import (
-    get_image_model, get_test_image_file)
-
-from wagtailtrans import models
+from wagtail.images.tests.utils import get_image_model, get_test_image_file
 
 from tests._sandbox.pages.models import HomePage
 from tests.factories import language
+from wagtailtrans import models
 
 
 class TranslatableSiteRootFactory(factory.DjangoModelFactory):

--- a/tests/factories/sites.py
+++ b/tests/factories/sites.py
@@ -1,11 +1,9 @@
 import factory
-
 from wagtail.core.models import Site
-
-from wagtailtrans import models
 
 from tests.factories.language import LanguageFactory
 from tests.factories.pages import HomePageFactory, TranslatableSiteRootFactory
+from wagtailtrans import models
 
 
 class SiteFactory(factory.DjangoModelFactory):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,9 @@
 import pytest
 from wagtail.core.models import Page, Site
 
-from wagtailtrans.models import Language, TranslatableSiteRootPage
-
-from tests.factories.requests import RequestFactory
 from tests._sandbox.pages.models import HomePage
+from tests.factories.requests import RequestFactory
+from wagtailtrans.models import Language, TranslatableSiteRootPage
 
 LANG_CODES = ['es', 'fr', 'de', 'nl', 'en']
 

--- a/tests/unit/test_edit_handlers.py
+++ b/tests/unit/test_edit_handlers.py
@@ -1,8 +1,8 @@
 import pytest
 
-from wagtailtrans.edit_handlers import ReadOnlyWidget, CanonicalPageWidget
-from wagtailtrans.models import Language
 from tests.factories import sites
+from wagtailtrans.edit_handlers import CanonicalPageWidget, ReadOnlyWidget
+from wagtailtrans.models import Language
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -1,11 +1,10 @@
+import pytest
 from django.forms.widgets import Select
 from django.test import override_settings
-
-import pytest
-from tests.factories import sites
 from wagtail.contrib.settings.views import get_setting_edit_handler
-from wagtailtrans.models import (Language, SiteLanguages,
-                                 register_site_languages)
+
+from tests.factories import sites
+from wagtailtrans.models import Language, SiteLanguages, register_site_languages
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,8 +1,8 @@
+import pytest
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import override_settings
 
-import pytest
 from tests.factories.language import LanguageFactory
 from tests.factories.sites import SiteFactory, SiteLanguagesFactory
 from wagtailtrans.middleware import TranslationMiddleware

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,7 @@
+import six
 import pytest
 from django.core.exceptions import ValidationError
 from django.test import override_settings
-from django.utils import six
 from wagtail.admin.edit_handlers import get_form_for_model
 
 from tests.factories.language import LanguageFactory

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,14 +1,13 @@
-import six
 import pytest
+import six
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 from wagtail.admin.edit_handlers import get_form_for_model
 
 from tests.factories.language import LanguageFactory
 from tests.factories.pages import TranslatablePageFactory
-from tests.factories.sites import SiteFactory, create_site_tree, SiteLanguagesFactory
+from tests.factories.sites import SiteFactory, SiteLanguagesFactory, create_site_tree
 from tests.factories.users import UserFactory
-
 from wagtailtrans import models
 
 

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,13 +1,11 @@
 import pytest
-
 from django.contrib.auth.models import Permission
 from django.test import override_settings
 
-from wagtailtrans.models import Language
-from wagtailtrans import permissions
-
-from tests.factories.users import UserFactory
 from tests.factories import sites
+from tests.factories.users import UserFactory
+from wagtailtrans import permissions
+from wagtailtrans.models import Language
 
 
 @pytest.mark.django_db
@@ -45,4 +43,3 @@ class TestTranslatableUserProxyPermission:
         permission = permissions.TranslatableUserPagePermissionsProxy(self.editor_user)
         # Only Super user can delete, Though permission has given
         assert not permission.for_page(self.last_page).can_delete()
-

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,12 +1,11 @@
 import pytest
 from django.test import override_settings
 
+from tests.factories import language, sites
+from tests.factories.pages import HomePageFactory, WagtailPageFactory
 from wagtailtrans import signals
 from wagtailtrans.models import Language, SiteLanguages, TranslatablePage
 from wagtailtrans.signals import register_signal_handlers
-
-from tests.factories import language, sites
-from tests.factories.pages import HomePageFactory, WagtailPageFactory
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_sites.py
+++ b/tests/unit/test_sites.py
@@ -1,9 +1,8 @@
 import pytest
 from django.test import override_settings
 
-from wagtailtrans import sites
-
 from tests.factories.sites import SiteFactory, SiteLanguagesFactory
+from wagtailtrans import sites
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_templatetags.py
+++ b/tests/unit/test_templatetags.py
@@ -3,8 +3,7 @@ from django.test import override_settings
 
 from tests.factories.pages import TranslatablePageFactory, WagtailPageFactory
 from tests.factories.sites import SiteFactory, create_site_tree
-from wagtailtrans.templatetags import (
-    translations_wagtail_admin, wagtailtrans_tags)
+from wagtailtrans.templatetags import translations_wagtail_admin, wagtailtrans_tags
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -4,10 +4,9 @@ from django.db.models import signals
 from django.http import Http404
 from django.test import override_settings
 
+from tests.factories import language, pages, sites
 from wagtailtrans.models import TranslatablePage
 from wagtailtrans.views.translation import TranslationView
-
-from tests.factories import language, pages, sites
 
 
 @pytest.mark.django_db

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{35,36,37}-dj111-wt{2,21,22,23,24},
-    py{35,36,37}-dj21-wt{23,24,25,26},
-    py{35,36,37}-dj22-wt{25,26},
+    py{35,36}-dj{111,20,21}-wt23,
+    py{35,36,37,38}-dj{20,21,22}-wt27,
+    py{35,36,37,38}-dj{21,22,30}-wt28,
     wagtaildev,
     flake8,
 
@@ -13,35 +13,34 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 install_command = pip install -e ".[test]" -U {opts} {packages}
 commands =
     py.test --cov=wagtailtrans --cov-report=xml tests/
 deps =
     dj111: django>=1.11,<2.0
+    dj20: django>=2.0,<2.1
     dj21: django>=2.1,<2.2
     dj22: django>=2.2,<3
-    wt2: wagtail>=2.0,<2.1
-    wt21: wagtail>=2.1,<2.2
-    wt22: wagtail>=2.1,<2.2
+    dj30: django>=3.0,<3.1
     wt23: wagtail>=2.3,<2.4
-    wt24: wagtail>=2.4,<2.5
-    wt25: wagtail>=2.5,<2.6
-    wt26: wagtail>=2.6,<2.7
+    wt27: wagtail>=2.7,<2.8
+    wt28: wagtail==2.8rc1
 setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings
 
 [testenv:wagtaildev]
-basepython = python3.6
+basepython = python3.7
 install_command = pip install -e ".[test]" -U {opts} {packages}
 deps =
     git+https://github.com/wagtail/wagtail.git@master
-    django>=2.0
+    django>=3.0
 commands =
     py.test --cov=wagtailtrans --cov-report=xml tests/
 ignore_errors = True
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 skip_install = True
 commands =
     flake8 src

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ usedevelop = True
 envlist =
     py{35,36}-dj{111,20,21}-wt23,
     py{35,36,37,38}-dj{20,21,22}-wt27,
-    py{35,36,37,38}-dj{21,22,30}-wt28,
+    py{35,36,37,38}-dj{21,22}-wt28,
+    py{36,37,38}-dj{30}-wt28,
     wagtaildev,
     flake8,
 


### PR DESCRIPTION
In order to prepare for Wagtail 2.8 and Django 3.0 we will need another release (#173). As the importing of static has changed. 

- As Django 1.11 is officially supported until april I kept the reference to Wagtail 2.3 intact.
- I cleaned up extra tests in between 2.3 and 2.7 (which I added and is the new LTS)

The current Tox and Travis setup is based upon the combinations which are defined in the overview of compatible Django and Python version as listed in the [documentation](https://docs.wagtail.io/en/latest/releases/upgrading.html#compatible-django-python-versions).
