### PR TITLE
Make Wagtail 2.10 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,31 @@ matrix:
       python: 3.7
     - env: TOXENV=py38-dj30-wt29
       python: 3.8
+    
+    # Wagtail 2.10
+    # Django 2.2
+    - env: TOXENV=py36-dj22-wt210
+      python: 3.6
+    - env: TOXENV=py37-dj22-wt210
+      python: 3.7
+    - env: TOXENV=py38-dj22-wt210
+      python: 3.8
+
+    # Django 3.0
+    - env: TOXENV=py36-dj30-wt210
+      python: 3.6
+    - env: TOXENV=py37-dj30-wt210
+      python: 3.7
+    - env: TOXENV=py38-dj30-wt210
+      python: 3.8
+    
+    # Django 3.1
+    - env: TOXENV=py36-dj31-wt210
+      python: 3.6
+    - env: TOXENV=py37-dj31-wt210
+      python: 3.7
+    - env: TOXENV=py38-dj31-wt210
+      python: 3.8
 
     # Flake 8
     - env: TOXENV=flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,6 @@ addons:
 
 matrix:
   include:
-    # Wagtail 2.3 LTS to cover support until 2.7
-    # Django 1.11
-    - env: TOXENV=py35-dj111-wt23
-      python: 3.5
-    - env: TOXENV=py36-dj111-wt23
-      python: 3.6
-
-    # Django 2.0
-    - env: TOXENV=py35-dj20-wt23
-      python: 3.5
-    - env: TOXENV=py36-dj20-wt23
-      python: 3.6
-
-    # Django 2.1
-    - env: TOXENV=py35-dj21-wt23
-      python: 3.5
-    - env: TOXENV=py36-dj21-wt23
-      python: 3.6
-    
     # Wagtail 2.7 LTS
     # Django 2.0
     - env: TOXENV=py35-dj20-wt27

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,25 @@ matrix:
     - env: TOXENV=py38-dj30-wt28
       python: 3.8
 
+    # Wagtail 2.9  
+    # Django 2.2
+    - env: TOXENV=py35-dj22-wt29
+      python: 3.5
+    - env: TOXENV=py36-dj22-wt29
+      python: 3.6
+    - env: TOXENV=py37-dj22-wt29
+      python: 3.7
+    - env: TOXENV=py38-dj22-wt29
+      python: 3.8
+
+    # Django 3.0
+    - env: TOXENV=py36-dj30-wt29
+      python: 3.6
+    - env: TOXENV=py37-dj30-wt29
+      python: 3.7
+    - env: TOXENV=py38-dj30-wt29
+      python: 3.8
+
     # Flake 8
     - env: TOXENV=flake8
       python: 3.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 2.2 (XX-XX-XXXX)
 ----------------
 
+- Added official support for Wagtail 2.9 and 2.10
+- Make the permission `can_delete` compatible with Wagtail 2.10
+- Make the page method `move` compatible with Wagtail 2.10
 - Dropped support for Wagtail versions earlier than 2.7
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 2.2 (XX-XX-XXXX)
 ----------------
 
+- Dropped support for Wagtail versions earlier than 2.7
 
 
 2.1 (03-02-2020)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ Changelog
 - Added official support for Wagtail 2.9 and 2.10
 - Make the permission `can_delete` compatible with Wagtail 2.10
 - Make the page method `move` compatible with Wagtail 2.10
-- Dropped support for Wagtail versions earlier than 2.7
+- Dropped support for Wagtail versions earlier than 2.7 (LTS)
+- Replace deprecated ugettext, ugettext_lazy with gettext and gettext_lazy
+- Replace deprecated force_text with force_str
 
 
 2.1 (03-02-2020)

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Requirements
 ------------
 
  - Python 3.5+
- - Django 1.11+
- - Wagtail 2.3+
+ - Django 2+
+ - Wagtail 2.7+
 
 
 Getting started

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from wagtailtrans import get_version  # noqa isort:skip
 sandbox_require = [
     'Django>=3.0',
     'Wagtail>=2.8rc1',
-    'psycopg2>=2.5.4',
+    'psycopg2-binary>=2.5.4',
     'djangorestframework>=3.7',
 ]
 
@@ -27,7 +27,7 @@ tests_require = [
     'pytest-django',
     'coverage',
     'factory-boy',
-    'psycopg2>=2.5.4',
+    'psycopg2-binary>=2.5.4',
     # Linting
     'flake8',
     'isort',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ sandbox_require = [
     'Django>=3.0',
     'Wagtail>=2.8rc1',
     'psycopg2-binary>=2.5.4',
-    'djangorestframework>=3.7',
 ]
 
 docs_require = [

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,9 @@ setup(
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Framework :: Wagtail',
+        'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,13 @@ PROJECT_DIR = os.path.dirname(__file__)
 sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from wagtailtrans import get_version  # noqa isort:skip
 
+install_requires = [
+    'wagtail>=2.7,<2.11'
+]
+
 sandbox_require = [
-    'Django>=3.0',
-    'Wagtail>=2.8rc1',
+    'Django>=3.1',
+    'Wagtail>=2.10',
     'psycopg2-binary>=2.5.4',
 ]
 
@@ -39,6 +43,7 @@ setup(
     author='Lukkien BV',
     author_email='support@lukkien.com',
     url='https://lukkien.com/',
+    install_requires=install_requires,
     extras_require={
         'test': tests_require,
         'doc': docs_require,

--- a/src/wagtailtrans/apps.py
+++ b/src/wagtailtrans/apps.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger()
 

--- a/src/wagtailtrans/forms.py
+++ b/src/wagtailtrans/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from wagtail.core.models import Page
 
 from wagtailtrans.models import TranslatablePage

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -172,7 +172,7 @@ class TranslatablePage(Page):
         activate(self.language.code)
         return super().serve(request, *args, **kwargs)
 
-    def move(self, target, pos=None, suppress_sync=False):
+    def move(self, target, pos=None, suppress_sync=False, *args, **kwargs):
         """Move the page to another target.
 
         :param target: the new target to move the page to
@@ -180,7 +180,7 @@ class TranslatablePage(Page):
         :param suppress_sync: suppress syncing the translated pages
 
         """
-        super().move(target, pos)
+        super().move(target, pos, *args, **kwargs)
 
         if get_wagtailtrans_setting('LANGUAGES_PER_SITE'):
             site = self.get_site()

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -7,10 +7,10 @@ from django.db import models
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import redirect
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import activate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 from wagtail.contrib.settings.models import BaseSetting
@@ -107,7 +107,7 @@ class Language(models.Model):
         verbose_name_plural = _('Languages')
 
     def __str__(self):
-        return force_text(dict(settings.LANGUAGES).get(self.code))
+        return force_str(dict(settings.LANGUAGES).get(self.code))
 
     def has_pages_in_site(self, site):
         return self.pages.filter(path__startswith=site.root_page.path).exists()

--- a/src/wagtailtrans/permissions.py
+++ b/src/wagtailtrans/permissions.py
@@ -77,7 +77,7 @@ def create_group_page_permission(page, language):
 class TranslatablePagePermissionTester(PagePermissionTester):
     """Custom permissions tester for translatable pages."""
 
-    def can_delete(self):
+    def can_delete(self, *args, **kwargs):
         """Check if a page can be deleted
         We make the check if the translated sites are kept in sync and
         if the page is a translated page (it has a canonical page)
@@ -91,7 +91,7 @@ class TranslatablePagePermissionTester(PagePermissionTester):
             not self.user.is_superuser
         ):
             return False
-        return super().can_delete()
+        return super().can_delete(*args, **kwargs)
 
 
 class TranslatableUserPagePermissionsProxy(UserPagePermissionsProxy):

--- a/src/wagtailtrans/views/translation.py
+++ b/src/wagtailtrans/views/translation.py
@@ -1,6 +1,6 @@
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.views.generic import CreateView
 
 from wagtailtrans.forms import TranslationForm

--- a/src/wagtailtrans/wagtail_hooks.py
+++ b/src/wagtailtrans/wagtail_hooks.py
@@ -1,9 +1,9 @@
 from django.conf.urls import include, url
 from django.templatetags.static import static
 from django.urls import reverse
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin import widgets
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
@@ -78,7 +78,7 @@ if not get_wagtailtrans_setting('SYNC_TREE'):
         translation_targets = other_languages - taken_languages
         for language in translation_targets:
             yield widgets.Button(
-                force_text(language),
+                force_str(language),
                 reverse('wagtailtrans_translations:add', kwargs={
                     'instance_id': page.pk,
                     'language_code': language.code,
@@ -152,7 +152,7 @@ def edit_in_language_items(page, page_perms, is_parent=False):
         next_url = reverse('wagtailadmin_explore', args=(return_page.get_parent().pk,))
 
         yield widgets.Button(
-            force_text(language_page.language),
+            force_str(language_page.language),
             "{edit_url}?next={next_url}".format(
                 edit_url=edit_url,
                 next_url=next_url

--- a/tests/factories/language.py
+++ b/tests/factories/language.py
@@ -3,7 +3,7 @@ import factory
 from wagtailtrans import models
 
 
-class LanguageFactory(factory.DjangoModelFactory):
+class LanguageFactory(factory.django.DjangoModelFactory):
     code = 'en-gb'
     position = 0
     is_default = True

--- a/tests/factories/pages.py
+++ b/tests/factories/pages.py
@@ -7,7 +7,7 @@ from tests.factories import language
 from wagtailtrans import models
 
 
-class TranslatableSiteRootFactory(factory.DjangoModelFactory):
+class TranslatableSiteRootFactory(factory.django.DjangoModelFactory):
     title = 'translatable-site-root'
     depth = 2
 
@@ -24,7 +24,7 @@ class TranslatableSiteRootFactory(factory.DjangoModelFactory):
         return root.add_child(title=kwargs['title'])
 
 
-class TranslatablePageFactory(factory.DjangoModelFactory):
+class TranslatablePageFactory(factory.django.DjangoModelFactory):
     language = factory.SubFactory(language.LanguageFactory)
 
     class Meta:
@@ -38,7 +38,7 @@ class TranslatablePageFactory(factory.DjangoModelFactory):
         return obj
 
 
-class ImageFactory(factory.DjangoModelFactory):
+class ImageFactory(factory.django.DjangoModelFactory):
     title = factory.Faker('word')
     file = get_test_image_file()
 
@@ -66,7 +66,7 @@ class HomePageFactory(TranslatablePageFactory):
         return obj
 
 
-class WagtailPageFactory(factory.DjangoModelFactory):
+class WagtailPageFactory(factory.django.DjangoModelFactory):
     depth = 0
     title = 'root'
 

--- a/tests/factories/sites.py
+++ b/tests/factories/sites.py
@@ -6,7 +6,7 @@ from tests.factories.pages import HomePageFactory, TranslatableSiteRootFactory
 from wagtailtrans import models
 
 
-class SiteFactory(factory.DjangoModelFactory):
+class SiteFactory(factory.django.DjangoModelFactory):
     hostname = 'localhost'
     port = 8000
     site_name = 'TestSite'
@@ -36,7 +36,7 @@ def create_site_tree(language, site=None, *items, **homepage_kwargs):
     return pages
 
 
-class SiteLanguagesFactory(factory.DjangoModelFactory):
+class SiteLanguagesFactory(factory.django.DjangoModelFactory):
     site = factory.SubFactory(SiteFactory)
     default_language = factory.SubFactory(LanguageFactory)
 

--- a/tests/factories/users.py
+++ b/tests/factories/users.py
@@ -2,7 +2,7 @@ import factory
 from django.contrib.auth import get_user_model
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
 
     first_name = 'John'
     last_name = 'Doe'

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{35,36,37,38}-dj{22}-wt29,
     py{36,37,38}-dj{30}-wt28,
     py{36,37,38}-dj{30}-wt29,
+    py{36,37,38}-dj{22,30,31}-wt210,
     wagtaildev,
     flake8,
 
@@ -27,6 +28,7 @@ deps =
     wt27: wagtail>=2.7,<2.8
     wt28: wagtail>=2.8,<2.9
     wt29: wagtail>=2.9,<2.10
+    wt210: wagtail>=2.10,<2.11
 setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ usedevelop = True
 envlist =
     py{35,36,37,38}-dj{20,21,22}-wt27,
     py{35,36,37,38}-dj{21,22}-wt28,
+    py{35,36,37,38}-dj{22}-wt29,
     py{36,37,38}-dj{30}-wt28,
+    py{36,37,38}-dj{30}-wt29,
     wagtaildev,
     flake8,
 
@@ -24,6 +26,7 @@ deps =
     dj30: django>=3.0,<3.1
     wt27: wagtail>=2.7,<2.8
     wt28: wagtail>=2.8,<2.9
+    wt29: wagtail>=2.9,<2.10
 setenv =
     DJANGO_SETTINGS_MODULE=tests._sandbox.settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 skipsdist = True
 usedevelop = True
 envlist =
-    py{35,36}-dj{111,20,21}-wt23,
     py{35,36,37,38}-dj{20,21,22}-wt27,
     py{35,36,37,38}-dj{21,22}-wt28,
     py{36,37,38}-dj{30}-wt28,
@@ -19,12 +18,10 @@ install_command = pip install -e ".[test]" -U {opts} {packages}
 commands =
     py.test --cov=wagtailtrans --cov-report=xml tests/
 deps =
-    dj111: django>=1.11,<2.0
     dj20: django>=2.0,<2.1
     dj21: django>=2.1,<2.2
     dj22: django>=2.2,<3
     dj30: django>=3.0,<3.1
-    wt23: wagtail>=2.3,<2.4
     wt27: wagtail>=2.7,<2.8
     wt28: wagtail>=2.8,<2.9
 setenv =


### PR DESCRIPTION
- Added official support for Wagtail 2.9 and 2.10
- Make the permission `can_delete` compatible with Wagtail 2.10
- Make the page method `move` compatible with Wagtail 2.10
- Dropped support for Wagtail versions earlier than 2.7 (LTS)
- Replace deprecated ugettext, ugettext_lazy with gettext and gettext_lazy
- Replace deprecated force_text with force_str

Fixes #186