### PR TITLE
Do not append language code to slug while synchronizing translation tree

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -23,3 +23,4 @@ Contributors
  - Nazmul Hasan
  - Michael van de Waeter
  - Michael van Tellingen
+ - Mateusz Kleinert

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -63,3 +63,16 @@ available sites.
 If set to ``True`` the CMS user will only see the tree of the canonical
 language, with an ``edit in`` button where they can choose the language to edit
 the page in.
+
+
+``WAGTAILTRANS_APPEND_LANGUAGE_TO_SLUG``
+--------------------------
+
+:Default: ``True``
+
+If set to ``False`` and ``WAGTAILTRANS_SYNC_TREE`` set to ``True`` wagtailtrans will
+not add language code as a suffix for a slug of newly created page during the translation
+trees synchronization.
+
+.. seealso::
+    The documentation about :ref:`synchronized_trees`

--- a/src/wagtailtrans/conf.py
+++ b/src/wagtailtrans/conf.py
@@ -4,6 +4,7 @@ DEFAULT_SETTINGS = {
     'SYNC_TREE': True,
     'LANGUAGES_PER_SITE': False,
     'HIDE_TRANSLATION_TREES': False,
+    'APPEND_LANGUAGE_TO_SLUG': True,
 }
 
 

--- a/src/wagtailtrans/middleware.py
+++ b/src/wagtailtrans/middleware.py
@@ -3,7 +3,6 @@ from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import LANGUAGE_SESSION_KEY, check_for_language, get_language_from_path
 from django.utils.translation.trans_real import get_languages, get_supported_language_variant
-
 from wagtail.core.models import Site
 
 from .models import Language

--- a/src/wagtailtrans/models.py
+++ b/src/wagtailtrans/models.py
@@ -256,13 +256,14 @@ class TranslatablePage(Page):
         )
         return translation_parent
 
-    def create_translation(self, language, copy_fields=False, parent=None):
+    def create_translation(self, language, copy_fields=False, parent=None, append_language_to_slug=True):
         """Create a translation for this page. If tree syncing is enabled the
         copy will also be moved to the corresponding language tree.
 
         :param language: Language instance
         :param copy_fields: Boolean specifying if the content should be copied
         :param parent: Parent page instance for the translation
+        :param append_language_to_slug: Boolean specifying if the language code should be used as a suffix for slug
         :return: new Translated page (or subclass) instance
 
         """
@@ -274,8 +275,10 @@ class TranslatablePage(Page):
 
         if self.slug == self.language.code:
             slug = language.code
-        else:
+        elif append_language_to_slug:
             slug = '%s-%s' % (self.slug, language.code)
+        else:
+            slug = self.slug
 
         update_attrs = {
             'title': self.title,

--- a/src/wagtailtrans/signals.py
+++ b/src/wagtailtrans/signals.py
@@ -49,8 +49,9 @@ def synchronize_trees(sender, instance, **kwargs):
     if not kwargs.get('created') or not getattr(instance, 'language', False) or not is_default_language:
         return
 
+    append_language_to_slug = get_wagtailtrans_setting('APPEND_LANGUAGE_TO_SLUG')
     for lang in other_languages:
-        instance.create_translation(language=lang, copy_fields=True)
+        instance.create_translation(language=lang, copy_fields=True, append_language_to_slug=append_language_to_slug)
 
 
 @disable_for_loaddata


### PR DESCRIPTION
Hello, there is an issue created some time ago - #178 - which I believe this PR can solve.

With `WAGTAILTRANS_SYNC_TREE` set to `True` we can end up with paths like this one: `/fr/products-fr/` assuming that the `fr` is not the default language. This is due to synchronizing translation tree algorithm which makes use of `create_translation()` method from `TranslatablePage`. As `create_translation()` can be used in a different contexts it tampers the `slug` value trying to make it unique. With `WAGTAILTRANS_SYNC_TREE` set to `True` we don't need to append language code to slug as the translated page is going to exist in a different sub-tree than the canonical page.

After some experiments I think the `synchronize_trees()` signal handler is the right place for a fix. However, I'd love to get some feedback and discuss alternatives.